### PR TITLE
Add Resources section and style blog post links

### DIFF
--- a/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
+++ b/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
@@ -157,4 +157,9 @@ If you're trying to model something similar, and it doesn't even have to be bras
 
 ---
 
-*If you found this interesting, the [technical documentation](/documentation/parametric-brass-insert-library) has the full variable reference and design notes. Download the library from [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) or [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1). You can follow more of my hardware project work at [OffGrid Devices](https://offgriddevices.com/).*
+## Resources
+
+- [Technical Documentation](/documentation/parametric-brass-insert-library) — Full variable reference, formulas, pitch lookup, and design notes
+- [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) — Master Shapr3D file and all size exports
+- [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1) — Individual STEP/STL files for 18 sizes
+- [OffGrid Devices](https://offgriddevices.com/) — More hardware project work

--- a/src/app/_components/markdown-styles.module.css
+++ b/src/app/_components/markdown-styles.module.css
@@ -74,3 +74,21 @@
   @apply pl-6 border-l-4 border-neutral-300 italic;
   color: #555;
 }
+
+/* Links */
+.markdown a {
+  @apply text-blue-600 underline underline-offset-2 decoration-blue-300 font-medium;
+  transition: color 0.15s, text-decoration-color 0.15s;
+}
+
+.markdown a:hover {
+  @apply text-blue-800 decoration-blue-500;
+}
+
+:global(.dark) .markdown a {
+  @apply text-blue-400 decoration-blue-600;
+}
+
+:global(.dark) .markdown a:hover {
+  @apply text-blue-300 decoration-blue-400;
+}


### PR DESCRIPTION
## Summary
- Added a dedicated **Resources** section to the brass insert blog post, replacing the closing italic paragraph where links were buried in prose
- Added link styling to `markdown-styles.module.css` — blog post links now render with blue color, underline, and hover states (light + dark mode) so they're clearly clickable

## Why
Links in blog post markdown content had zero custom styling, making them visually indistinguishable from regular text. The technical documentation link existed but was effectively invisible.

## Test plan
- [ ] Verify links in the brass insert blog post appear blue and underlined
- [ ] Verify hover state changes color
- [ ] Verify dark mode link colors
- [ ] Confirm the Resources section renders at the bottom of the post
- [ ] Check that links across other blog posts also pick up the new styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)