### PR TITLE
Fix: remove phantom M3×3×4.2 and reconcile size count to 18

### DIFF
--- a/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
+++ b/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
@@ -120,14 +120,13 @@ Another lesson: when a CAD tool throws a weird error, it's usually telling you t
 
 ## What I ended up with
 
-One Shapr3D file with four input variables: `threadSize`, `length`, `outerDiameter`, and `pitch`, which is auto-computed from the first one. Every length and every diameter of every zone is computed. I can model any size from M2×2×3.2 up to M6×10×8 by changing three numbers and hitting enter. Twenty sizes from one master file.
+One Shapr3D file with four input variables: `threadSize`, `length`, `outerDiameter`, and `pitch`, which is auto-computed from the first one. Every length and every diameter of every zone is computed. I can model any size from M2×2×3.2 up to M6×10×8 by changing three numbers and hitting enter. Eighteen sizes from one master file.
 
 The file includes modeled knurls, internal threads, the stepped pilot geometry, and pitch-scaled chamfers, all driven from the same variable set. Change the three main dimensions and the whole insert updates cleanly. Everything just works.
 
 ![Rendered Shapr3D brass heat-set insert with modeled knurls, gap, pilot, and internal threads](/blog/content/brass-insert-render.webp)
 
-If you want to study or adapt the file yourself, I also wrote a **[complete technical reference doc](/documentation/parametric-brass-insert-library)** covering the variables, formulas, pitch lookup, and current limitations. The published Shapr3D master file and exports are on [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) and [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1). The GrabCAD listing currently mirrors 18 of the 20 size combinations as individual files; the full master file is on Printables.
-
+If you want to study or adapt the file yourself, I also wrote a **[complete technical reference doc](/documentation/parametric-brass-insert-library)** covering the variables, formulas, pitch lookup, and current limitations. The published Shapr3D master file and exports are on [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) and [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1).
 ## Other brass inserts exist (and they're different)
 
 The inserts I modeled are the "double-knurled" style: two opposing helical knurl bands with a smooth gap in the middle. These are by far the most common type sold for 3D printing, and they're what you'll find in every budget assortment kit on Amazon. But there are other types worth knowing about:

--- a/documentation/brass-insert-documentation.md
+++ b/documentation/brass-insert-documentation.md
@@ -6,7 +6,7 @@ date: "2026-04-14T00:00:00.000Z"
 
 **Technical Documentation & Variable Reference**
 
-A fully parametric CAD library for generating ISO metric brass heat-set inserts in Shapr3D, covering all 20 sizes from M2×2×3.2 through M6×10×8. Change three input values: thread size, length, and outer diameter, and every dimension of the insert updates automatically, including the helical knurls, internal threads, chamfers, pilot geometry, and necked gap.
+A fully parametric CAD library for generating ISO metric brass heat-set inserts in Shapr3D, covering all 18 sizes from M2×2×3.2 through M6×10×8. Change three input values: thread size, length, and outer diameter, and every dimension of the insert updates automatically, including the helical knurls, internal threads, chamfers, pilot geometry, and necked gap.
 
 ![Rendered brass heat-set insert from the Shapr3D parametric library](/blog/content/brass-insert-render.webp)
 
@@ -53,7 +53,7 @@ The library is calibrated for these nominal sizes:
 |---|---|
 | M2 | 2×3.2, 4×3.2, 6×3.2, 8×3.2 |
 | M2.5 | 2.5×3.5, 4×3.5, 6×3.5 |
-| M3 | 3×4.2, 4×4.2, 6×4.2, 8×4.2, 10×4.2 |
+| M3 | 4×4.2, 6×4.2, 8×4.2, 10×4.2 |
 | M4 | 6×6, 8×6, 10×6 |
 | M5 | 6×7, 8×7 |
 | M6 | 8×8, 10×8 |
@@ -266,8 +266,8 @@ If the file is slow on very small inserts or you do not need internal threads fo
 Published packages (see [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) or [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1)) typically ship:
 
 - `brass-insert-master.shapr` — the master Shapr3D file with all variables and history
-- `brass-insert-[size].step` — individual STEP exports for each of the 20 common sizes
-- `brass-insert-[size].stl` — individual STL exports for each of the 20 common sizes
+- `brass-insert-[size].step` — individual STEP exports for each of the 18 common sizes
+- `brass-insert-[size].stl` — individual STL exports for each of the 18 common sizes
 - `README.md` — a condensed version of this documentation for quick reference
 - `pitch-lookup-table.png` — optional visual reference for the six ISO pitches (when included in a given release archive)
 


### PR DESCRIPTION
## Summary

The INCLY 440-piece kit label only has M3 starting at length 4: M3×4×4.2, M3×6×4.2, M3×8×4.2, M3×10×4.2. The doc incorrectly listed **M3×3×4.2** which doesn't exist in the kit.

- Removed `3×4.2` from the M3 row in the documentation size table
- Updated all "20 sizes" → "18 sizes" references in both blog and doc
- Removed the GrabCAD clarification sentence from the blog (counts now match: 18 everywhere)

Total: M2(4) + M2.5(3) + M3(4) + M4(3) + M5(2) + M6(2) = **18 sizes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)