### PR TITLE
Parametric insert library: radius-based variables, groove-angle scaling, blog rewrite

### DIFF
--- a/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
+++ b/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
@@ -40,13 +40,15 @@ I measured one of my M6×10×8 inserts with calipers and wrote down all ten dime
 
 ![Dimensioned Shapr3D model of the brass insert showing the five axial zones and derived dimensions](/blog/content/brass-insert-dimensioned-model.webp)
 
-## The second surprise: ratios are your friend, until they aren't
+## Ratios are your friend
 
-The length ratios turned out to be consistent across sizes. The pilot is always about 22% of the total length, split between the locating lip and the necked-in upper portion. The two knurl bands are about 30–33% each. The gap is about 16%. Same with the diameters: the gap necks down to about 86% of the outer diameter, the pilot upper narrows further to 83%, and the pilot lip flares out to 88%.
+The length ratios turned out to be consistent across sizes. The pilot is always about 22% of the total length, split between the locating lip and the necked-in upper portion. The two knurl bands are about 30–33% each. The gap is about 16%. Same story on the radial side: the gap necks down to about 86% of the outer radius, the pilot upper narrows further to 83%, and the pilot lip flares out to 88%.
 
-This was beautiful until I tried to model the internal threads.
+One small thing I had to be careful about: Shapr3D's revolve tool spins a 2D profile around an axis, which means every radial value in the sketch is a *radius*, not a diameter. So even though the inserts are spec'd by outer *diameter* (the "3.2" in "M2×2×3.2"), everything in the model has to be halved first. I set up a single derived variable called `outerRadius = outerDiameter_changeMe / 2` and made every radial ratio read from that: `gapRadius = outerRadius × 0.86`, and so on. Naming them `...Radius` keeps the semantics honest — if they were called `...Diameter` but held half-sized values, every downstream math operation would be a loaded gun.
 
-## The third surprise: you don't actually need real threads
+This was all beautiful, right up until I tried to model the internal threads.
+
+## You don't actually need real threads
 
 Here's something nobody tells you when you start CAD: **most vendors don't model functional threads inside their published part files.** CNC Kitchen, ruthex, McMaster-Carr: none of their public CAD files for heat-set inserts have real helical threads inside the bore. They're just smooth holes.
 
@@ -76,9 +78,9 @@ The lesson: when you pull a formula off the internet, know what geometric assump
 
 ## The parametric workaround I was told wouldn't work
 
-Shapr3D's variable system is great. You define inputs like `length`, `outerDiameter`, `threadSize` and everything else flows from formulas. Change one number, the whole model updates.
+Shapr3D's variable system is great. You define inputs like `length_changeMe`, `outerDiameter_changeMe`, `threadSize_changeMe` and everything else flows from formulas. The `_changeMe` suffix is a deliberate UX hint: when you open the Variables panel and see 25 rows, it's instantly obvious which three you're allowed to touch. Change one of those three numbers, the whole model updates.
 
-The one thing it doesn't support is conditional logic. There's no `if threadSize == 6 then pitch = 1.0`. No if-statements, no lookup tables, no switch expressions. Just arithmetic.
+The one thing Shapr3D doesn't support is conditional logic. There's no `if threadSize_changeMe == 6 then pitch = 1.0`. No if-statements, no lookup tables, no switch expressions. Just arithmetic.
 
 This was a problem, because ISO metric pitch isn't a clean formula. It's a lookup table:
 
@@ -98,19 +100,21 @@ But I found a workaround using `sign()` and `abs()`. The expression `1 - sign(ab
 Here's the actual formula pasted verbatim from my file:
 
 ```
-pitch = (0.4 * (1 - sign(abs(threadSize - 2 mm)))
-       + 0.45 * (1 - sign(abs(threadSize - 2.5 mm)))
-       + 0.5 * (1 - sign(abs(threadSize - 3 mm)))
-       + 0.7 * (1 - sign(abs(threadSize - 4 mm)))
-       + 0.8 * (1 - sign(abs(threadSize - 5 mm)))
-       + 1 * (1 - sign(abs(threadSize - 6 mm)))) mm
+pitch = (0.4 * (1 - sign(abs(threadSize_changeMe - 2 mm)))
+       + 0.45 * (1 - sign(abs(threadSize_changeMe - 2.5 mm)))
+       + 0.5 * (1 - sign(abs(threadSize_changeMe - 3 mm)))
+       + 0.7 * (1 - sign(abs(threadSize_changeMe - 4 mm)))
+       + 0.8 * (1 - sign(abs(threadSize_changeMe - 5 mm)))
+       + 1 * (1 - sign(abs(threadSize_changeMe - 6 mm)))) mm
 ```
 
 It's ugly. I love it. It means I only ever type *one* number to set the thread size, and the pitch updates automatically across the entire model.
 
+The same `min(a, b) = (a + b − |a − b|) / 2` identity ended up showing up in two other places too — capping the groove diameter so it never exceeds 80% of the gap length, and capping the groove angle so extreme aspect ratios don't spiral out (more on that in a bit). It's become my favorite trick in a variable system without if-statements.
+
 ## The thread touching problem
 
-The final wall I hit: when the revolve angle was exactly 360° per pitch, which is what ISO specifies, the triangular thread profiles tried to touch each other at their corners, and Shapr3D threw an error.
+The next wall I hit: when the revolve angle was exactly 360° per pitch, which is what ISO specifies, the triangular thread profiles tried to touch each other at their corners, and Shapr3D threw an error.
 
 The fix was obvious once I understood it: a real ISO thread isn't a pure triangle. It has small *crest flats* between adjacent threads. In geometry terms, that means the triangle base has to be smaller than one full pitch period, leaving a tiny gap at the top and bottom of each turn. I changed `baseWidth` to `pitch × 0.75` and updated `threadDepth` to `baseWidth × 0.866`, keeping the 60° angle intact, and the error went away.
 
@@ -118,15 +122,52 @@ Another lesson: when a CAD tool throws a weird error, it's usually telling you t
 
 ![Thread profile cross-section showing the bore wall, brass body, baseWidth = pitch × 0.75, crest flats of pitch × 0.125 on each side, 60° apex angle, and axis of revolution](/blog/content/brass-insert-thread-profile-anatomy.png)
 
+## One angle doesn't fit all
+
+The threads were done. I turned my attention to the knurls — the diagonal grooves that give the insert its grip once it's melted into plastic.
+
+The approach is straightforward on paper: sketch a small circle on the outer surface, revolve it a few degrees along a short helical path, and you get a single diagonal groove. Then circular-pattern it around the insert's axis and you've got a whole band. Flip the helix direction for the second band so the grooves run the opposite way.
+
+On the M6×10×8 I'd been modeling, a 45° revolve angle looked exactly right. So I used `45 deg` everywhere and moved on.
+
+Then I started plugging in other sizes, and the grooves stopped reading as knurls. On short, fat inserts like M2×2×3.2, the grooves were way too steep — they looked almost vertical. On long, thin inserts like M6×10×8 itself, they were fine, because that's what I'd calibrated against. The problem wasn't the angle I'd picked. It was that *the right angle depends on the shape of the insert*. A square-ish body wants a gentler helix than a tall skinny one, because the helix has less circumference to wrap around before it runs out of band length.
+
+The fix was to make the angle a function of the aspect ratio:
+
+```
+grooveAngleRaw = length_changeMe / outerDiameter_changeMe * 60 deg
+grooveAngleMax = 100 deg
+grooveAngle    = (grooveAngleRaw + grooveAngleMax
+                  - abs(grooveAngleRaw - grooveAngleMax)) / 2
+```
+
+The first line says: the groove angle is proportional to how tall the insert is relative to its width. I calibrated the `60 deg` multiplier so that a perfectly square insert (`length = OD`, ratio = 1.0) gets 60° grooves, and everything else scales from there. The M4×6×6 and M6×8×8 land at exactly 60° — which looks right — and the old M6×10×8 baseline comes out to 75°, which also looks right.
+
+The second and third lines cap the result at 100° using the same `min()` identity from the pitch formula. Without the cap, an M2×8×3.2 (ratio = 2.5) computes to `grooveAngleRaw = 150°`, which wraps the groove so far around the insert that it reverses direction and produces garbage. Six of the nineteen sizes hit the cap — all the tallest variants of the smallest-OD inserts — and the cap just keeps them at a reasonable steep-but-sane 100°.
+
+Here's what ends up happening across the library:
+
+| Insert | L ÷ OD | grooveAngle |
+|---|---|---|
+| M2×2×3.2 | 0.63 | 37.5° |
+| M3×4×4.2 | 0.95 | 57.1° |
+| M4×6×6 | 1.00 | 60.0° |
+| M6×10×8 | 1.25 | 75.0° |
+| M3×8×4.2 | 1.90 | 100.0° (capped) |
+| M2×8×3.2 | 2.50 | 100.0° (capped) |
+
+Same formula, nineteen different visually appropriate results. This is the moment parametric design starts paying for itself — you pick the hard numbers once (`60`, `100`), and they propagate everywhere.
+
 ## What I ended up with
 
-One Shapr3D file with four input variables: `threadSize`, `length`, `outerDiameter`, and `pitch`, which is auto-computed from the first one. Every length and every diameter of every zone is computed. I can model any size from M2×2×3.2 up to M6×10×8 by changing three numbers and hitting enter. Eighteen sizes from one master file.
+One Shapr3D file with three input variables — `threadSize_changeMe`, `length_changeMe`, `outerDiameter_changeMe` — plus `pitch`, which is auto-computed from the first one. Every length and every radius of every zone is derived. I can model any size from M2×2×3.2 up to M6×10×8 by changing three numbers and hitting enter. Nineteen sizes from one master file.
 
-The file includes modeled knurls, internal threads, the stepped pilot geometry, and pitch-scaled chamfers, all driven from the same variable set. Change the three main dimensions and the whole insert updates cleanly. Everything just works.
+The file includes modeled knurls (with angle-scaling), internal threads, the stepped pilot geometry, and pitch-scaled chamfers, all driven from the same variable set. Change the three main dimensions and the whole insert updates cleanly. Everything just works.
 
 ![Rendered Shapr3D brass heat-set insert with modeled knurls, gap, pilot, and internal threads](/blog/content/brass-insert-render.webp)
 
 If you want to study or adapt the file yourself, I also wrote a **[complete technical reference doc](/documentation/parametric-brass-insert-library)** covering the variables, formulas, pitch lookup, and current limitations. The published Shapr3D master file and exports are on [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) and [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1).
+
 ## Other brass inserts exist (and they're different)
 
 The inserts I modeled are the "double-knurled" style: two opposing helical knurl bands with a smooth gap in the middle. These are by far the most common type sold for 3D printing, and they're what you'll find in every budget assortment kit on Amazon. But there are other types worth knowing about:
@@ -140,7 +181,7 @@ My parametric file only covers the double-knurled style. If you need one of the 
 
 ## What I'd tell someone else thinking about trying this
 
-Honestly? If you'd shown me a picture of my final variable panel on day one, 25 variables and half of them driven by formulas referencing other formulas, I would have closed the tab. It looks impossible.
+Honestly? If you'd shown me a picture of my final variable panel on day one, 25+ variables and half of them driven by formulas referencing other formulas, I would have closed the tab. It looks impossible.
 
 But here's the thing: **every one of those variables got added one at a time, in response to a specific problem I was trying to solve.** I didn't sit down and plan the whole thing up front. The model just got more explicit each time the geometry forced me to clarify another relationship. Each addition took maybe 20–30 minutes of fiddling, most of which was staring at something broken and slowly understanding why.
 
@@ -148,11 +189,15 @@ If you're trying to model something similar, and it doesn't even have to be bras
 
 **Measure the real thing with calipers first.** I wasted time early on trying to work from product listings and Amazon descriptions. The actual part in your hand has information no spec sheet captures. Measure it, write the numbers down, and don't trust anything until you've verified it physically.
 
-**Work in ratios, not absolute values.** The moment I wrote `lowerKnurlLength = length × 0.33` instead of `lowerKnurlLength = 3.3 mm`, the model became reusable. One formula, twenty sizes. That's the whole point of parametric design.
+**Work in ratios, not absolute values.** The moment I wrote `lowerKnurlLength = length_changeMe × 0.33` instead of `lowerKnurlLength = 3.3 mm`, the model became reusable. One formula, nineteen sizes. That's the whole point of parametric design.
+
+**Name variables for what they *are*, not what they look like.** A radius should be called a radius, not a diameter. A raw intermediate value should read as intermediate. Good names make wrong math visible; bad names hide it.
 
 **When a CAD error is confusing, the geometry probably has a subtlety you're missing.** Don't fight the error. Read it, believe it, and go figure out what real-world constraint it's pointing at. It's almost always right.
 
 **It's okay to make visual-only simplifications, but know which ones you're making.** I could have skipped the internal threads entirely and nobody would have noticed. I chose to include them anyway because I wanted to understand how they work. That's a legitimate reason. "It matters for the screw to function" is not.
+
+**If one parameter only looks right at one size, make it a function of the inputs.** My first pass used a hardcoded 45° groove angle. It looked great on the insert I calibrated against and weird on everything else. The fix was to let the angle scale with the insert's aspect ratio. Hardcoded constants are almost always calibrated to the thing you're currently staring at.
 
 **Use AI as a sparring partner.** I talked through most of this project with Claude, not to have it build the model for me, but to have someone to bounce geometry questions off of. "Why is my apex angle 69° when it should be 60°?" is a question that would take me an hour to Google and ten seconds to get a useful answer to in a chat. The answer is only useful if you can evaluate it, so you're still doing the thinking, but the feedback loop is dramatically faster than forum-hunting.
 
@@ -164,5 +209,5 @@ If you're trying to model something similar, and it doesn't even have to be bras
 
 - [Technical Documentation](/documentation/parametric-brass-insert-library) — Full variable reference, formulas, pitch lookup, and design notes
 - [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) — Master Shapr3D file and all size exports
-- [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1) — Individual STEP/STL files for 18 sizes
+- [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1) — Individual STEP/STL files for 19 sizes
 - [OffGrid Devices](https://offgriddevices.com/) — More hardware project work

--- a/documentation/brass-insert-documentation.md
+++ b/documentation/brass-insert-documentation.md
@@ -6,7 +6,7 @@ date: "2026-04-14T00:00:00.000Z"
 
 **Technical Documentation & Variable Reference**
 
-A fully parametric CAD library for generating ISO metric brass heat-set inserts in Shapr3D, covering all 18 sizes from M2×2×3.2 through M6×10×8. Change three input values: thread size, length, and outer diameter, and every dimension of the insert updates automatically, including the helical knurls, internal threads, chamfers, pilot geometry, and necked gap.
+A fully parametric CAD library for generating ISO metric brass heat-set inserts in Shapr3D, covering all 19 sizes from M2×2×3.2 through M6×10×8. Change three input values — thread size, length, and outer diameter — and every dimension of the insert updates automatically, including the helical knurls, internal threads, chamfers, pilot geometry, and necked gap. Input variables carry a `_changeMe` suffix so it's obvious at a glance which three fields you actually edit; everything else is derived.
 
 ![Rendered brass heat-set insert from the Shapr3D parametric library](/blog/content/brass-insert-render.webp)
 
@@ -43,7 +43,7 @@ The "double-knurled" style this library models is the most common variant sold i
 - An **upper knurl band** with diagonal grooves running the opposite direction
 - **Internal threads** matching standard ISO metric coarse (ISO 261)
 
-The library generates dimensionally accurate models of this style across the entire M2–M6 range, with every feature parameterized so a single file can be reused for all 20 common sizes.
+The library generates dimensionally accurate models of this style across the entire M2–M6 range, with every feature parameterized so a single file can be reused for all 19 common sizes.
 
 ## Supported Size Range
 
@@ -53,7 +53,7 @@ The library is calibrated for these nominal sizes:
 |---|---|
 | M2 | 2×3.2, 4×3.2, 6×3.2, 8×3.2 |
 | M2.5 | 2.5×3.5, 4×3.5, 6×3.5 |
-| M3 | 4×4.2, 6×4.2, 8×4.2, 10×4.2 |
+| M3 | 3×4.2, 4×4.2, 6×4.2, 8×4.2, 10×4.2 |
 | M4 | 6×6, 8×6, 10×6 |
 | M5 | 6×7, 8×7 |
 | M6 | 8×8, 10×8 |
@@ -66,14 +66,14 @@ The ratios were derived from measurements of a 440-piece INCLY assortment kit. O
 
 1. Open the Shapr3D file.
 2. Open the Variables panel from the History sidebar.
-3. Change exactly three variables:
-   - `threadSize` — the M number (2, 2.5, 3, 4, 5, or 6)
-   - `length` — total insert length in mm
-   - `outerDiameter` — outer diameter of the brass body in mm
+3. Change exactly three variables — the ones with the `_changeMe` suffix:
+   - `threadSize_changeMe` — the M number as mm (2, 2.5, 3, 4, 5, or 6)
+   - `length_changeMe` — total insert length in mm
+   - `outerDiameter_changeMe` — outer diameter of the brass body in mm
 4. All other dimensions recompute automatically. The model updates in real time.
 5. Export as STEP, STL, or your preferred format.
 
-That's it. You don't need to touch any of the derived variables unless you want to adapt the library for a different supplier's inserts.
+That's it. The `_changeMe` suffix is a deliberate UX cue — if it doesn't have that suffix, you don't need to touch it unless you're adapting the library for a different supplier's inserts.
 
 ---
 
@@ -83,40 +83,48 @@ That's it. You don't need to touch any of the derived variables unless you want 
 
 ### Input Variables
 
-These are the three, well, four: pitch is technically computed but you'll never touch it manually, variables you change when generating a new size.
+These are the three variables you change when generating a new size. They carry a `_changeMe` suffix so they stand out in the Variables panel — every other variable is derived and shouldn't be edited by hand.
 
 | Variable | Type | Description |
 |---|---|---|
-| `threadSize` | Number | The M-number for the thread (2, 2.5, 3, 4, 5, or 6). Unitless. |
-| `length` | Length | Total axial length of the insert in mm. |
-| `outerDiameter` | Length | Outer diameter of the brass body (the widest point of the knurl bands) in mm. |
-| `pitch` | Length | Thread pitch. Auto-computed from `threadSize` via the [pitch lookup formula](#the-pitch-formula). |
+| `threadSize_changeMe` | Length | The M-number as mm (2, 2.5, 3, 4, 5, or 6). |
+| `length_changeMe` | Length | Total axial length of the insert in mm. |
+| `outerDiameter_changeMe` | Length | Outer diameter of the brass body (the widest point of the knurl bands) in mm. |
+| `pitch` | Length | Thread pitch. Auto-computed from `threadSize_changeMe` via the [pitch lookup formula](#the-pitch-formula). Don't edit. |
+
+### Derived Radius Variable
+
+Shapr3D revolves around an axis and therefore works in radii, not diameters. A single derived value bridges the OD input to the radius-based sketch:
+
+| Variable | Formula | Purpose |
+|---|---|---|
+| `outerRadius` | `outerDiameter_changeMe / 2` | Half the outer diameter. Every other radial value downstream is expressed as a fraction of this. |
 
 ### Body Length Proportions
 
-The insert length is divided into five axial zones, each scaled as a fraction of `length`. These ratios were derived by measuring a physical M6×10×8 insert and verified across the other sizes in the assortment kit.
+The insert length is divided into five axial zones, each scaled as a fraction of `length_changeMe`. These ratios were derived by measuring a physical M6×10×8 insert and verified across the other sizes in the assortment kit.
 
-| Variable | Formula | Purpose |
+| Variable | Formula | M3×8×4.2 value |
 |---|---|---|
-| `upperKnurlLength` | `length * 0.3` | Length of the upper knurl band |
-| `gapLength` | `length * 0.166` | Length of the necked gap between knurls |
-| `lowerKnurlLength` | `length * 0.33` | Length of the lower knurl band |
-| `pilotUpperLength` | `length * 0.125` | Length of the necked-in upper pilot section |
-| `pilotLowerLength` | `length * 0.095` | Length of the locating lip at the tip |
+| `upperKnurlLength` | `length_changeMe * 0.30` | 2.4 mm |
+| `gapLength` | `length_changeMe * 0.166` | 1.328 mm |
+| `lowerKnurlLength` | `length_changeMe * 0.33` | 2.64 mm |
+| `pilotUpperLength` | `length_changeMe * 0.125` | 1.0 mm |
+| `pilotLowerLength` | `length_changeMe * 0.095` | 0.76 mm |
 
 These five zones add up to `length × 1.016`, which accounts for the typical 1.6% manufacturing over-run observed in the assortment kit inserts: nominal 10 mm inserts physically measured closer to 10.16 mm. If this doesn't match your supplier, adjust the ratios. See [Customization Guide](#customization-guide).
 
-### Body Diameter Proportions
+### Body Radius Proportions
 
-The insert has three distinct diameter tiers, each expressed as a fraction of `outerDiameter`. The knurl bands themselves sit at the full outer diameter.
+The insert has three distinct radial tiers, each expressed as a fraction of `outerRadius`. All values are radii (distance from the centerline axis to the surface), not diameters — this is what the revolve sketch consumes.
 
-| Variable | Formula | Purpose |
-|---|---|---|
-| `gapDiameter` | `outerDiameter * 0.86` | Necked gap between the two knurl bands |
-| `pilotUpperDiameter` | `outerDiameter * 0.83` | Narrowest point of the pilot (the upper neck) |
-| `pilotLowerDiameter` | `outerDiameter * 0.88` | The locating lip at the very tip |
+| Variable | Formula | M3×8×4.2 value | Purpose |
+|---|---|---|---|
+| `gapRadius` | `outerRadius * 0.86` | 1.806 mm | Necked gap between the two knurl bands |
+| `pilotUpperRadius` | `outerRadius * 0.83` | 1.743 mm | Narrowest point of the pilot (the upper neck) |
+| `pilotLowerRadius` | `outerRadius * 0.88` | 1.848 mm | The locating lip at the very tip |
 
-The knurl bands themselves are drawn at the full `outerDiameter`. There's no variable for this because it's just the input value.
+The knurl bands themselves sit at the full `outerRadius`. There's no variable for this because it's just `outerDiameter_changeMe / 2`.
 
 ### Thread Geometry
 
@@ -124,13 +132,13 @@ The internal threads are real ISO metric coarse helical threads, modeled by revo
 
 ![Top view of the modeled internal threads and upper knurl band](/blog/content/brass-insert-render-top.webp)
 
-| Variable | Formula | Purpose |
-|---|---|---|
-| `boreDiameter` | `threadSize - pitch` | ISO tap drill diameter (standard rule). For M6 = 5.0 mm. |
-| `threadLength` | `length * 0.75` | Portion of the insert that gets threads cut into it |
-| `baseWidth` | `pitch * 0.75` | Axial length of the triangle base (on the bore wall) |
-| `threadDepth` | `baseWidth * 0.866` | Radial depth of the triangle (keeps apex at exactly 60°) |
-| `revolveAngle` | `threadLength / pitch * 360 deg` | Total revolve rotation (one full turn per pitch period) |
+| Variable | Formula | M3×8×4.2 value | Purpose |
+|---|---|---|---|
+| `boreRadius` | `(threadSize_changeMe - pitch) / 2` | 1.25 mm | Inner bore radius — ISO tap drill diameter ÷ 2. For M3, bore Ø = 2.5 mm. |
+| `threadLength` | `length_changeMe * 0.8` | 6.4 mm | Portion of the insert that gets threads cut into it |
+| `baseWidth` | `pitch * 0.75` | 0.375 mm | Axial length of the triangle base (on the bore wall) |
+| `threadDepth` | `baseWidth * 0.866` | 0.3248 mm | Radial depth of the triangle (keeps apex at exactly 60°) |
+| `revolveAngle` | `threadLength / pitch * 360 deg` | 4,608° | Total revolve rotation (one full turn per pitch period) |
 
 **Why `baseWidth = pitch × 0.75` instead of `pitch`:** Using the full pitch for the triangle base causes adjacent thread profiles to touch at their corners during the revolve, which Shapr3D rejects with an "invalid contact" error. Shrinking the base to 75% of pitch leaves small crest flats between adjacent threads, which is how real ISO threads are actually shaped anyway. The 25% reduction in base width gets redistributed as uncut bore wall, crest flats, at the top and bottom of each pitch period.
 
@@ -142,28 +150,72 @@ The internal threads are real ISO metric coarse helical threads, modeled by revo
 
 The top and bottom of the bore get 45° chamfers to create a lead-in for screws and to smoothly terminate the internal threads.
 
-| Variable | Formula | Purpose |
-|---|---|---|
-| `chamferSize` | `pitch * 0.5` | Equal-distance chamfer size for both top and bottom bore edges |
+| Variable | Formula | M3×8×4.2 value | Purpose |
+|---|---|---|---|
+| `chamferSize` | `pitch * 0.5` | 0.25 mm | Equal-distance chamfer size for both top and bottom bore edges |
 
-For M6, pitch = 1, this produces a 0.5 mm chamfer that opens the bore mouth from `boreDiameter`, 5 mm, to exactly `threadSize`, 6 mm. This is standard machining practice for tapped holes. The chamfer's wide end equals the nominal screw diameter, providing a clean lead-in without cutting into the threads themselves.
+The chamfer opens the bore mouth by `chamferSize` radially on each side, creating a clean lead-in and smoothly terminating the internal threads at both ends. For M6 (pitch = 1 mm) this is 0.5 mm, opening the bore from a 5 mm tap drill up to the 6 mm nominal thread diameter — standard machining practice for tapped holes.
 
 ![Bottom view of the insert showing the chamfered bore opening and internal threads](/blog/content/brass-insert-render-bottom.webp)
 
 ### Knurl Grooves
 
-The diagonal grooves on the two knurl bands are created by sketching a small circle in a square, revolving it 45° along a short helical path to form a single groove, then circular-patterning that groove around the insert.
+The diagonal grooves on the two knurl bands are created by sketching a small circle in a square, revolving it along a short helical path to form a single groove, then circular-patterning that groove around the insert. The revolve angle is no longer hardcoded at 45° — it now scales with the insert's length-to-OD ratio so short/fat inserts get shallower grooves and tall/thin ones get steeper grooves.
 
-| Variable | Formula | Purpose |
-|---|---|---|
-| `grooveCount` | `floor(outerDiameter * 3.14 / 1 mm)` | Number of grooves in the circular pattern |
-| `grooveByOD` | `outerDiameter * 0.11` | Ideal groove diameter based on outer diameter |
-| `grooveByGap` | `gapLength * 0.8` | Maximum groove diameter based on gap length |
-| `grooveDiameter` | `(grooveByOD + grooveByGap - abs(grooveByOD - grooveByGap)) / 2` | Final groove diameter, the smaller of `grooveByOD` and `grooveByGap` |
+**Groove size and count:**
+
+| Variable | Formula | M3×8×4.2 value | Purpose |
+|---|---|---|---|
+| `grooveCount` | `floor(outerDiameter_changeMe * 3.14 / 1 mm)` | 13 | Number of grooves in the circular pattern |
+| `grooveByOD` | `outerRadius * 0.11` | 0.231 mm | Ideal groove diameter based on the radius-scaled sketch |
+| `grooveByGap` | `gapLength * 0.8` | 1.0624 mm | Maximum groove diameter that still fits within the gap |
+| `grooveDiameter` | `(grooveByOD + grooveByGap - abs(grooveByOD - grooveByGap)) / 2` | 0.231 mm | Final groove diameter — the smaller of `grooveByOD` and `grooveByGap` |
+
+**Groove angle (scales with aspect ratio):**
+
+| Variable | Formula | M3×8×4.2 value | Purpose |
+|---|---|---|---|
+| `grooveAngleRaw` | `length_changeMe / outerDiameter_changeMe * 60 deg` | 114.3° | Raw angle from the insert's length-to-OD ratio |
+| `grooveAngleMax` | `100 deg` | 100° | Upper cap on the final groove angle |
+| `grooveAngle` | `(grooveAngleRaw + grooveAngleMax - abs(grooveAngleRaw - grooveAngleMax)) / 2` | 100° (capped) | Final revolve angle — the smaller of `grooveAngleRaw` and `grooveAngleMax` |
+
+Use `grooveAngle` for both the upper and lower knurl revolves, flipping the height direction between them to get the two opposing groove slopes.
 
 **Why `grooveCount` uses `floor(OD × π / 1 mm)`:** Groove density should be constant around the circumference, not a fixed count. Larger inserts have more circumference and need more grooves to look right, while smaller inserts need fewer. The formula gives roughly one groove per 1 mm of circumference, which visually matches the reference inserts. The `/ 1 mm` strips the length unit so `floor()` operates on a plain number.
 
+**Why `grooveByOD` is driven by `outerRadius`, not `outerDiameter`:** The 0.11 multiplier was calibrated against the radius value used in the revolve sketch. If this were driven off `outerDiameter_changeMe` instead, the grooves would be roughly twice the intended size and would cut through the gap zone into the knurl bands.
+
 **Why `grooveDiameter` uses a min() workaround:** Shapr3D has no `min()` function, so the algebraic identity `min(a, b) = (a + b - |a - b|) / 2` is used instead. This caps the groove diameter at whichever is smaller: the OD-based value, good for most sizes, or 80% of the gap length, which prevents grooves from spilling into adjacent knurl bands on small, squat inserts like M2×2×3.2. Without this cap, the M2×2×3.2 groove circle would be slightly wider than the gap between its knurl bands, and the revolve would chew into the wrong zone.
+
+**Why `grooveAngle` uses length-to-OD ratio:** A single hardcoded 45° angle looked fine on the M6×10×8 I first measured, but the slope read wrong on squat inserts (M2×2×3.2) and too lazy on tall ones (M6×10×8). The length-to-OD ratio is a cheap proxy for "how tall-and-thin is this insert," and calibrating at `× 60 deg` makes a perfectly square (ratio = 1.0) insert like M4×6×6 or M6×8×8 land on 60°. Everything else scales from there.
+
+**Why the `100 deg` cap:** Tall, thin inserts like M2×8×3.2 (ratio = 2.5) compute to `grooveAngleRaw = 150°`, which would wrap the groove so far around the insert that it effectively reverses direction. Capping at 100° prevents that failure mode. The cap is applied with the same `min()` identity used for `grooveDiameter`. Six of the 19 sizes hit the cap — all tall variants of small-OD inserts.
+
+**Tuning:** Increase the `60 deg` multiplier for steeper grooves everywhere, decrease it for shallower ones. Raise or lower `grooveAngleMax` to allow more or less extreme angles. Both are single-number edits that propagate across every size.
+
+#### Resulting groove angles across the library
+
+| Insert | L ÷ OD | `grooveAngle` |
+|---|---|---|
+| M2×2×3.2 | 0.63 | 37.5° |
+| M2×4×3.2 | 1.25 | 75.0° |
+| M2×6×3.2 | 1.88 | 100.0° (capped) |
+| M2×8×3.2 | 2.50 | 100.0° (capped) |
+| M2.5×2.5×3.5 | 0.71 | 42.9° |
+| M2.5×4×3.5 | 1.14 | 68.6° |
+| M2.5×6×3.5 | 1.71 | 100.0° (capped) |
+| M3×3×4.2 | 0.71 | 42.9° |
+| M3×4×4.2 | 0.95 | 57.1° |
+| M3×6×4.2 | 1.43 | 85.7° |
+| M3×8×4.2 | 1.90 | 100.0° (capped) |
+| M3×10×4.2 | 2.38 | 100.0° (capped) |
+| M4×6×6 | 1.00 | 60.0° |
+| M4×8×6 | 1.33 | 80.0° |
+| M4×10×6 | 1.67 | 100.0° (capped) |
+| M5×6×7 | 0.86 | 51.4° |
+| M5×8×7 | 1.14 | 68.6° |
+| M6×8×8 | 1.00 | 60.0° |
+| M6×10×8 | 1.25 | 75.0° |
 
 ---
 
@@ -183,19 +235,19 @@ ISO 261 metric coarse thread pitches don't follow a clean mathematical relations
 There's no simple formula that maps M2 → 0.40 and M6 → 1.00 and all the values between them. Shapr3D has no if-statements or lookup tables either. The workaround is to build a lookup using the `sign()` and `abs()` functions:
 
 ```
-pitch = (0.4  * (1 - sign(abs(threadSize - 2   mm)))
-       + 0.45 * (1 - sign(abs(threadSize - 2.5 mm)))
-       + 0.5  * (1 - sign(abs(threadSize - 3   mm)))
-       + 0.7  * (1 - sign(abs(threadSize - 4   mm)))
-       + 0.8  * (1 - sign(abs(threadSize - 5   mm)))
-       + 1    * (1 - sign(abs(threadSize - 6   mm)))) mm
+pitch = (0.4  * (1 - sign(abs(threadSize_changeMe - 2   mm)))
+       + 0.45 * (1 - sign(abs(threadSize_changeMe - 2.5 mm)))
+       + 0.5  * (1 - sign(abs(threadSize_changeMe - 3   mm)))
+       + 0.7  * (1 - sign(abs(threadSize_changeMe - 4   mm)))
+       + 0.8  * (1 - sign(abs(threadSize_changeMe - 5   mm)))
+       + 1    * (1 - sign(abs(threadSize_changeMe - 6   mm)))) mm
 ```
 
-**How it works:** Each term evaluates to 1 when `threadSize` equals the target value, because `1 - sign(abs(0)) = 1 - 0 = 1`, and 0 otherwise, because `1 - sign(abs(nonzero)) = 1 - 1 = 0`. Multiplying by the desired pitch value and summing all six terms gives a selector. Exactly one term is nonzero at any time, and its coefficient becomes the output. The final `mm` suffix converts the scalar result back into a length.
+**How it works:** Each term evaluates to 1 when `threadSize_changeMe` equals the target value, because `1 - sign(abs(0)) = 1 - 0 = 1`, and 0 otherwise, because `1 - sign(abs(nonzero)) = 1 - 1 = 0`. Multiplying by the desired pitch value and summing all six terms gives a selector. Exactly one term is nonzero at any time, and its coefficient becomes the output. The final `mm` suffix converts the scalar result back into a length.
 
 **Known limitations of this approach:**
 
-1. **Only works for exact matches.** Setting `threadSize = 3.5`, which isn't a real ISO size but might be typed by mistake, returns pitch = 0, which will break downstream calculations. The formula only recognizes the six values baked into it.
+1. **Only works for exact matches.** Setting `threadSize_changeMe = 3.5`, which isn't a real ISO size but might be typed by mistake, returns pitch = 0, which will break downstream calculations. The formula only recognizes the six values baked into it.
 2. **Adding more sizes requires editing the formula.** Want to add M1.6 or M8 to the library? You have to expand the expression with additional `sign(abs(...))` terms.
 3. **Floating-point precision.** Shapr3D evaluates `sign()` and `abs()` with Parasolid's 1e-8 tolerance, which is more than enough headroom for the integer and half-integer M-sizes this formula uses. No precision issues observed in testing.
 4. **Unreadable at a glance.** Six months from now when you open the file, this expression will look like line noise. Paste the pitch lookup table as a comment or sticky note in the Shapr3D workspace so future-you remembers what it does.
@@ -210,8 +262,8 @@ This library is meant to be a reusable reference file. The `.shapr` file already
 
 At a high level:
 
-- You only need to change `threadSize`, `length`, and `outerDiameter` to generate a supported insert size.
-- The external body is driven by five axial zones and three derived diameter tiers.
+- You only need to change `threadSize_changeMe`, `length_changeMe`, and `outerDiameter_changeMe` to generate a supported insert size.
+- The external body is driven by five axial zones and three derived radius tiers.
 - The necked gap, pilot geometry, chamfers, knurls, and internal threads are all derived from formulas in the Variables panel and update automatically with the three user inputs.
 - Internal threads are included for visual completeness and learning value, but suppressing them still leaves a perfectly usable reference model for enclosure design and fit checks.
 - The file is intended for CAD reuse, fit checking, and visualization of common M2–M6 brass inserts. It is not intended to serve as manufacturing documentation for producing brass inserts from scratch.
@@ -222,9 +274,9 @@ At a high level:
 
 **Thread geometry is a simplified sharp triangle, not a true ISO trapezoid.** Real ISO metric threads have small flats at both the crest and root of the thread profile. This library uses a sharp triangle, apex = 60°, with a deliberate crest flat created by `baseWidth < pitch`, but no flat at the apex. The visual difference is imperceptible at M2–M6 scale, but technically the modeled thread has a slightly sharper root than a spec-compliant thread. For CAD visualization purposes this is fine. The library shouldn't be used to CNC-machine functional threads that need to pass inspection.
 
-**Knurl grooves are approximated as circular cuts, not true diamond knurling.** Real knurling is formed by rolling hardened tooling into the brass, which creates pyramidal diamond shapes rather than clean round grooves. This library approximates the visual effect with circular profiles revolved 45°, which reads as "knurled" from a normal viewing distance but wouldn't pass close inspection as anatomically correct. Again, this is fine for visualization but not for representing the exact surface for friction analysis.
+**Knurl grooves are approximated as circular cuts, not true diamond knurling.** Real knurling is formed by rolling hardened tooling into the brass, which creates pyramidal diamond shapes rather than clean round grooves. This library approximates the visual effect with circular profiles revolved through `grooveAngle`, which reads as "knurled" from a normal viewing distance but wouldn't pass close inspection as anatomically correct. Again, this is fine for visualization but not for representing the exact surface for friction analysis.
 
-**Ratios are calibrated to INCLY-brand inserts.** The length and diameter proportions come from measuring a specific assortment kit. Other suppliers, ruthex, CNC Kitchen, McMaster, may use different proportions, particularly for the pilot geometry. See [Customization Guide](#customization-guide) for adapting.
+**Ratios are calibrated to INCLY-brand inserts.** The length and radius proportions come from measuring a specific assortment kit. Other suppliers, ruthex, CNC Kitchen, McMaster, may use different proportions, particularly for the pilot geometry. See [Customization Guide](#customization-guide) for adapting.
 
 **Inserts are all double-knurled style.** The library doesn't cover tapered inserts, McMaster style, single-knurl inserts, RS Pro style, or press-fit inserts. A similar parametric approach would work for any of these, but the underlying body geometry would need to change.
 
@@ -240,8 +292,8 @@ At a high level:
 
 1. Get a few physical inserts from your supplier, in different sizes if possible.
 2. Measure each zone with calipers and record the dimensions.
-3. For a single size, divide each length measurement by the total length to get ratios. Divide each diameter measurement by the outer diameter to get diameter ratios.
-4. Update the five length ratios and three diameter ratios in the Variables panel.
+3. For a single size, divide each length measurement by the total length to get ratios. Divide each radial measurement by `outerRadius` (half the outer diameter) to get radius ratios.
+4. Update the five length ratios and three radius ratios in the Variables panel. Don't accidentally divide a diameter by `outerDiameter_changeMe` — the sketch expects radii.
 5. Check that the ratios sum to approximately 1.0 for lengths. If they don't, the nominal length on your supplier's label differs from the actual measured length by that factor. You can either accept the discrepancy or apply a fudge factor like `length_real = length_nominal * 1.016`.
 
 ### Adding new thread sizes to the pitch formula
@@ -249,15 +301,15 @@ At a high level:
 To add M1.6, M8, or another size, append a new term to the `pitch` formula:
 
 ```
-+ 0.2 * (1 - sign(abs(threadSize - 1.6 mm)))    // for M1.6
-+ 1.25 * (1 - sign(abs(threadSize - 8 mm)))     // for M8
++ 0.2 * (1 - sign(abs(threadSize_changeMe - 1.6 mm)))    // for M1.6
++ 1.25 * (1 - sign(abs(threadSize_changeMe - 8 mm)))     // for M8
 ```
 
 Look up the correct ISO pitch value for the size you're adding, ISO 261 tables are freely available online, and plug it in as the multiplier.
 
 ### Disabling internal threads for faster performance
 
-If the file is slow on very small inserts or you do not need internal threads for your use case, suppress the thread-cut history step. The bore remains as a smooth cylinder at `boreDiameter`, which is still perfectly usable for enclosure design, spacing checks, and most reference workflows.
+If the file is slow on very small inserts or you do not need internal threads for your use case, suppress the thread-cut history step. The bore remains as a smooth cylinder at `boreRadius` (i.e. the ISO tap-drill diameter), which is still perfectly usable for enclosure design, spacing checks, and most reference workflows.
 
 ---
 
@@ -266,8 +318,8 @@ If the file is slow on very small inserts or you do not need internal threads fo
 Published packages (see [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) or [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1)) typically ship:
 
 - `brass-insert-master.shapr` — the master Shapr3D file with all variables and history
-- `brass-insert-[size].step` — individual STEP exports for each of the 18 common sizes
-- `brass-insert-[size].stl` — individual STL exports for each of the 18 common sizes
+- `brass-insert-[size].step` — individual STEP exports for each of the 19 common sizes
+- `brass-insert-[size].stl` — individual STL exports for each of the 19 common sizes
 - `README.md` — a condensed version of this documentation for quick reference
 - `pitch-lookup-table.png` — optional visual reference for the six ISO pitches (when included in a given release archive)
 


### PR DESCRIPTION
## Summary

- **Documentation rewrite** for the parametric brass heat-set insert library: input variables are now `_changeMe`-suffixed, radial values are stored as true radii (not diameters), thread coverage bumped to 80% of insert length, and every variable table now includes worked M3×8×4.2 values.
- **New groove-angle scaling** — `grooveAngle` now adapts to the insert's length/OD ratio (`× 60 deg`, capped at `100 deg`) instead of a hardcoded 45°. Documented with the full angle table across all 19 sizes.
- **Blog rewrite** — the companion post is now one cohesive narrative covering all design decisions (ratios, radius semantics, thread geometry, pitch lookup, thread-touching fix, groove-angle scaling). No version-change framing.
- **M3×3×4.2 restored** to the supported-size table, bringing the library to 19 sizes.

## Test plan

- [ ] Verify the documentation page at `/documentation/parametric-brass-insert-library` renders cleanly (tables, code blocks, anchors).
- [ ] Verify the blog post at `/posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad` renders cleanly and all images load.
- [ ] Spot-check the pitch formula code block and groove-angle table are not mangled by markdown.
- [ ] Confirm internal links (blog ↔ documentation) still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)