### PR TITLE
Fix OffGrid Devices domain typo across site

### DIFF
--- a/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
+++ b/_posts/what-a-bag-of-brass-inserts-taught-me-about-parametric-cad.md
@@ -211,7 +211,7 @@ If you're trying to model something similar, and it doesn't even have to be bras
 - [Printables](https://www.printables.com/model/1689827-parametric-brass-threaded-heat-set-insert-library) — Master Shapr3D file and all size exports
 - [GrabCAD](https://grabcad.com/library/parametric-brass-threaded-heat-set-insert-library-m2-m6-18-sizes-1) — Individual STEP/STL files for 18 sizes
 - [440-piece INCLY brass insert kit on Amazon](https://amzn.to/4mFt8M8) — the exact kit I measured for this library (affiliate link)
-- [OffGrid Devices](https://offgriddevices.com/) — More hardware project work
+- [OffGrid Devices](https://offgridevices.com/) — More hardware project work
 
 ---
 

--- a/_projects/offgrid-devices.md
+++ b/_projects/offgrid-devices.md
@@ -3,6 +3,6 @@ title: "OffGrid Devices — MagSafe Gear for Meshtastic & MeshCore"
 date: "2026-01-25T00:00:00.000Z"
 description: "A solo maker business building MagSafe-compatible accessories and practical field gear for Meshtastic and MeshCore users, designed in Shapr3D and iterated through rapid 3D printing."
 image: "/project/offgrid-devices.jpg"
-projectUrl: "https://offgriddevices.com"
+projectUrl: "https://offgridevices.com"
 technologies: ["Shapr3D", "3D Printing", "Product Design", "E-commerce", "Meshtastic", "MeshCore", "Rapid Prototyping"]
 ---

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 const LINKS = {
   offgridDevices: {
-    site: "https://offgriddevices.com",
+    site: "https://offgridevices.com",
     etsy: "https://www.etsy.com/shop/OffGridDevices",
   },
   content: {
@@ -267,7 +267,7 @@ export default function LinksPage() {
             label="OffGrid Devices"
             description="MagSafe accessories for Meshtastic & MeshCore. Designed in Shapr3D, printed to order."
             icon={<ShopIcon />}
-            badge="offgriddevices.com"
+            badge="offgridevices.com"
             gradientFrom="#1a5c2e"
             gradientTo="#2d8a4e"
           />


### PR DESCRIPTION
## Summary
Corrects a typo in the OffGrid Devices domain name from "offgriddevices.com" to "offgridevices.com" across multiple files.

## Changes
- Updated the primary domain link in the links page configuration
- Fixed the badge display text on the OffGrid Devices card component
- Corrected the project URL in the OffGrid Devices project markdown file
- Updated the reference link in the brass inserts blog post

## Details
All instances of the incorrect domain "offgriddevices.com" have been replaced with the correct domain "offgridevices.com" to ensure consistent and accurate linking throughout the site and documentation.

https://claude.ai/code/session_01W9Ks7vqe5qhhj7AKQU2DBt