### PR TITLE
fix(build): retry embed fetch on transient network errors

### DIFF
--- a/scripts/build-embeddings.ts
+++ b/scripts/build-embeddings.ts
@@ -370,24 +370,56 @@ async function main() {
   const embedded: EmbeddedChunk[] = [];
   const model = PROMPT_CONFIG.embeddings.model;
 
-  // Batch in small groups — Ollama /api/embed accepts an input array
+  // Batch in small groups — Ollama /api/embed accepts an input array.
+  // Cloudflare Tunnel (and most proxies) will reset idle keep-alive connections,
+  // so any single fetch can hit ECONNRESET. Retry transient network errors and
+  // 5xx responses with exponential backoff.
   const batchSize = PROMPT_CONFIG.embeddings.batchSize;
+  const maxAttempts = 5;
+  const isTransient = (err: unknown) => {
+    const code = (err as { cause?: { code?: string }; code?: string } | null)?.cause?.code
+      ?? (err as { code?: string } | null)?.code;
+    return code === "ECONNRESET" || code === "UND_ERR_SOCKET" || code === "ETIMEDOUT"
+      || code === "ECONNREFUSED" || code === "EAI_AGAIN";
+  };
   for (let i = 0; i < all.length; i += batchSize) {
     const batch = all.slice(i, i + batchSize);
     const input = batch.map((d) => d.text);
     const embStart = Date.now();
-    const res = await fetch(`${embedUrl}/api/embed`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "authorization": `Bearer ${embedSecret}`,
-      },
-      body: JSON.stringify({ model, input }),
-    });
-    if (!res.ok) {
-      throw new Error(`embed upstream ${res.status}: ${await res.text()}`);
+    let payload: { embeddings: number[][] } | null = null;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const res = await fetch(`${embedUrl}/api/embed`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "authorization": `Bearer ${embedSecret}`,
+          },
+          body: JSON.stringify({ model, input }),
+        });
+        if (!res.ok) {
+          const body = await res.text();
+          if (res.status >= 500 && attempt < maxAttempts) {
+            const wait = 500 * 2 ** (attempt - 1);
+            console.warn(`[build-embeddings] upstream ${res.status}, retry ${attempt}/${maxAttempts - 1} in ${wait}ms`);
+            await new Promise((r) => setTimeout(r, wait));
+            continue;
+          }
+          throw new Error(`embed upstream ${res.status}: ${body}`);
+        }
+        payload = (await res.json()) as { embeddings: number[][] };
+        break;
+      } catch (err) {
+        if (attempt < maxAttempts && isTransient(err)) {
+          const wait = 500 * 2 ** (attempt - 1);
+          console.warn(`[build-embeddings] transient fetch error (${(err as Error).message}), retry ${attempt}/${maxAttempts - 1} in ${wait}ms`);
+          await new Promise((r) => setTimeout(r, wait));
+          continue;
+        }
+        throw err;
+      }
     }
-    const payload = (await res.json()) as { embeddings: number[][] };
+    if (!payload) throw new Error("embed: no payload after retries");
     const embEnd = Date.now();
     try {
       await captureAiEmbedding({ model, latencyMs: embEnd - embStart, input: input.slice(0, 1) });


### PR DESCRIPTION
## Summary
- Wrap the `scripts/build-embeddings.ts` POST to `${EMBED_URL}/api/embed` in a 5-attempt exponential-backoff retry.
- Retries on transient network errors (`ECONNRESET`, `UND_ERR_SOCKET`, `ETIMEDOUT`, `ECONNREFUSED`, `EAI_AGAIN`) and 5xx responses; backoff 0.5s → 1s → 2s → 4s.

## Why
The production deploy on commit `4852baa` failed with `TypeError: fetch failed` / `ECONNRESET` during the prebuild embedding step. Self-hosted Ollama runs behind Cloudflare Tunnel, which resets idle keep-alive connections and enforces per-request timeouts — a single dropped connection was failing the entire build. The Pi itself was healthy throughout.

## Test plan
- [x] `npm run build:index` locally against the Pi — all 125 chunks embedded, 1.74 MB index written
- [x] `tsc --noEmit` — no new errors
- [ ] Next production deploy completes the embedding step