### PR TITLE
chat: AI-focused identity opener + recency-biased project retrieval

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -6,7 +6,7 @@ LENGTH — most important rule. Read carefully:
   (a) The user explicitly asks for depth ("in detail", "tell me everything about", "walk me through").
   (b) The user explicitly asks for a list ("list your projects", "what have you built with X", "give me 5 posts"). For lists, one short bullet per item is fine.
 - Match the energy of the incoming message. "Yo"/"hey" → "Hey, what's up?" not a recap. Short question → short answer.
-- Bio-style questions ("what's your background?", "who are you?", "tell me about yourself") are NOT requests for depth. Answer in 2 sentences max — headline only (current role + maybe one notable thing). Do NOT chain together job history, side projects, home lab, hobbies, location, and contact info into one essay.
+- Bio-style questions ("what's your background?", "who are you?", "tell me about yourself", "what do you do?") get a short AI-focused intro. Lead with "I'm Shreyash Gupta — " followed by an AI-focused identity in 5–10 words (e.g. "AI-focused builder", "an AI-focused creator who works with data and hardware"). Optionally add ONE short clause about what you're building right now. Then stop. Do NOT chain together job history, side projects, home lab, hobbies, location, and contact info into one essay. End with a brief invitation to ask about something specific if it feels natural.
 - Never proactively dump information. No "Here's a quick rundown…", no "Sure thing, here's…", no scene-setting. Just answer.
 - No headers. No bullet lists unless the user explicitly asked for a list.
 
@@ -26,6 +26,11 @@ CONTENT TYPES — keep separate:
 
 TECHNOLOGY QUERIES (e.g. "what have you built with PyTorch?"):
 - This is one of the few cases where a list IS what they want. Surface every relevant project from Context, one short line each, with links.
+
+PROJECT RECENCY — bias toward recent work:
+- When the user asks about projects in general ("what have you built", "show me your projects", or any open-ended project question), default to the most recent projects in Context. Don't lead with old work.
+- When listing multiple projects, list the most recent first (top of Context order is your friend — Context is already biased toward recent for project queries).
+- Older projects ONLY come up when the user asks about a specific technology or topic that doesn't appear in recent work, or names an older project directly. In that case, answer with what's there — don't apologize for the project being old.
 
 VAGUE FOLLOW-UPS ("tell me more", "go on", "what else"):
 - Ask one short clarifying question naming 2 specific things from Context they could pick. Don't dump.

--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -267,6 +267,21 @@ export function hybridRetrieve(
     }
   });
 
+  // Recency boost for project documents. Calibrated to RRF score gaps
+  // (~0.001–0.005) so a recent project ranked ~10 beats an old project
+  // ranked ~1 on vague queries, but a tech-specific query that only
+  // matches old projects still surfaces them (no recent competition).
+  const now = Date.now();
+  for (const item of fused.values()) {
+    if (item.doc.type !== "project" || !item.doc.date) continue;
+    const ageDays = Math.max(0, (now - new Date(item.doc.date).getTime()) / 86400000);
+    let bonus = 0;
+    if (ageDays <= 90) bonus = 0.005;
+    else if (ageDays <= 180) bonus = 0.003;
+    else if (ageDays <= 365) bonus = 0.001;
+    item.score += bonus;
+  }
+
   const merged = Array.from(fused.values()).sort((a, b) => b.score - a.score);
   console.info(`[rag] Hybrid retrieval: dense=${dense.length}, lexical=${lexical.length}, fused=${merged.length}, keep=${k}`);
   return merged.slice(0, k).map((item) => item.doc);


### PR DESCRIPTION
## Summary

Two complementary changes to make the chat feel more on-brand and lead with current work:

**1. AI-focused identity opener (prompt change).** Bio-style questions ("who are you?", "what do you do?", "what's your background?", "tell me about yourself") now lead with `"I'm Shreyash Gupta — [AI-focused identity in 5–10 words]"` instead of the previous generic role-and-notable-thing framing. The model adds at most one short clause about what you're building right now, then ends with a brief invitation to ask about something specific. Stops it from chaining together job history + side projects + home lab + hobbies + location into one essay.

**2. Recency-biased project retrieval (`hybridRetrieve`).** Adds a small additive bonus to project documents based on date, applied after RRF fusion:

| Project age | Bonus |
|---|---|
| ≤ 90 days | +0.005 |
| 91 – 180 days | +0.003 |
| 181 – 365 days | +0.001 |
| > 365 days | 0 |

Calibrated to typical RRF score gaps (~0.001–0.005) so a recent project ranked ~10 in similarity beats an old project ranked ~1 on vague queries like "what have you built?". But — and this is the part that matters — tech-specific queries that only match older projects (e.g. "what ML projects have you built?", where every ML project is dated 2024-01-02) still surface those projects, because the older projects have no recent competition to outrank them. Posts and resume documents are unaffected; the boost is project-only.

Also adds a `PROJECT RECENCY` rule to the prompt so the model lists recent projects first when it has a choice.

## Verified locally

- "who are you?" → "I'm Shreyash Gupta — an AI-focused builder working with data and hardware. ..." (3 sentences, AI-focused identity, ends with invitation).
- "what do you do?" → same opener, mentions one current thing with link.
- "what have you built?" → leads with Self-Hosted AI Chat (Apr 2026), Federalist Papers (Mar 2026), OffGrid Devices (Jan 2026), TubeGenius (Jun 2025) — recent first.
- "what ML projects have you built?" → still surfaces all 4 ML projects (all 2024-01-02), confirming tech-specific fallback works when nothing recent matches.

## Test plan

- [ ] Verify Vercel preview deploy builds clean (no code changes affect the build path; only retrieval scoring + prompt).
- [ ] On the preview URL, hit the chat with the four queries above and confirm the behavior matches what's documented in the verified-locally section.
- [ ] Confirm specific-project queries ("tell me about TubeGenius") still answer specifically — the recency boost shouldn't drown out direct-name questions.

## Notes for follow-up

The recency boost runs at query time, not build time, so no index rebuild is required. If the calibration feels too strong/weak after a few days of real use, the four constants in `src/lib/rag.ts` are the only tuning knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)